### PR TITLE
update: remove PrismaService shutdown hook

### DIFF
--- a/data/blog/nestjs-prisma.mdx
+++ b/data/blog/nestjs-prisma.mdx
@@ -392,19 +392,13 @@ touch src/database/prisma.service.ts
 And then inside the file, add the following code:
 
 ```ts:prisma.service.ts
-import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {
   async onModuleInit() {
     await this.$connect();
-  }
-
-  async enableShutdownHooks(app: INestApplication) {
-    this.$on('beforeExit', async () => {
-      await app.close();
-    });
   }
 }
 ```


### PR DESCRIPTION
Prisma 5 removed the shutdown hook from Prisma Client, which is not required in the PrismaService.
